### PR TITLE
Add Docker Support [Enhancement]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bkp
 data/
 .vscode/
+.idea/
 config.yaml
 workspace.code-workspace
 *.ipynb

--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ Should work both with X6 and X7 versions.
 
 Recommended python version is python3.12
 
-    sh install_tools.sh
-    uv pip install -r requirements.txt
-    uv pip install -e .
+```bash
+sh install_tools.sh
+uv pip install -r requirements.txt
+uv pip install -e .
+```
 
 To install requirements for notebooks
-    
-    # this is probably outdated
-    sh install_nbs.sh
+
+```bash
+# this is probably outdated
+sh install_nbs.sh
+```
 
 ## To Run
 
@@ -25,8 +29,12 @@ To install requirements for notebooks
 ![plot](./data/screenshot.png)
 
 ## Configuration
+
 Environment variable **DEFAULT_PATH** pointing the Exposure library path. See template.env.
 
+## Docker Deployment
+
+For running ExposureStats in a Docker environment, please refer to the detailed instructions in [docker/README.md](https://github.com/luismavs/ExposureStats/blob/main/docker/README.md).
 
 ## Tests
 
@@ -34,10 +42,8 @@ Tests need an env var **test_image** set to a test file.
 
 ## Comments
 
-Notebook folder has an older version, jupyter + seaborn based. 
-
+Notebook folder has an older version, jupyter + seaborn based.
 
 ## To Do
 
 - Package/Deploy as a container?
-

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,41 @@
+# Version control
+.git
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+*.egg-info/
+dist/
+build/
+
+# Environment files
+.env
+template.env
+venv/
+.venv/
+
+# Development files
+.vscode/
+*.ipynb
+.ipynb_checkpoints/
+notebook/
+tests/
+docs/
+
+# Data
+data/
+*.bkp
+*.drawio
+*.excalidraw
+
+# Docker files
+docker/
+Dockerfile
+.dockerignore

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,45 @@
+# Docker
+
+<p align="center">
+  <img src="../data/docker.png" alt="Nutri-Score Logo" width="500">
+</p>
+
+Docker is an operating system level virtualization solution for delivering software in packages called containers.
+
+We assume users have Docker correctly installed on their computer if they wish to use this feature. Docker is available for Linux as well as MacOS and Windows. For more details visit: https://www.docker.com/
+
+## Running ExposureStats with Docker
+
+### Quick Start
+
+To run `ExposureStats` with docker, take the following steps:
+
+```bash
+# Clone the repository and change to directory
+git clone git@github.com:luismavs/ExposureStats.git
+cd ExposureStats
+
+# Set the DEFAULT_PATH environment variable in your terminal
+
+# 1.On Linux/macOS:
+export DEFAULT_PATH=/your/actual/path/to/library
+
+# 2.On Windows (PowerShell):
+$env:DEFAULT_PATH="/your/actual/path/to/library"
+
+# Build & run the docker image
+docker-compose -f docker/compose.yaml up --build
+
+```
+
+## Environment Variables
+
+Before running, make sure to set the `DEFAULT_PATH` on the terminal from the upper method or:
+
+- Create a `.env` file based on `template.env`
+- Set the DEFAULT_PATH to your Exposure library path
+- Set test_image for running tests (Optional)
+
+## Accessing the Application
+
+Once running, you can access the Streamlit interface at: http://localhost:8501

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  web:
+    build:
+      context: ..
+      dockerfile: docker/dockerfile
+    image: exposurestats
+    container_name: exposurestats
+    ports:
+      - "8080:8080"
+    volumes:
+      - ..:/app
+    environment:
+      - DEFAULT_PATH=${DEFAULT_PATH:?Please set DEFAULT_PATH}

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+COPY . .
+
+RUN pip install --no-cache-dir -U pip && \
+    pip install uv && \
+    uv venv .venv && \
+    . .venv/bin/activate && \
+    chmod +x install_tools.sh && \
+    sh install_tools.sh && \
+    pip install -r requirements.txt && \
+    pip install -e .
+
+ENTRYPOINT ["streamlit", "run", "src/exposurestats/app.py", "--server.port=8080", "--server.address=0.0.0.0"]


### PR DESCRIPTION
## Description
Added Docker support to make ExposureStats easier to deploy and run in a containerized environment.

### Added Files
- [docker/dockerfile](docker/dockerfile) - Base image using Python 3.12-slim with all required dependencies
- [docker/compose.yaml](docker/compose.yaml) - Docker Compose configuration for easy deployment
- [docker/.dockerignore](docker/.dockerignore) - Optimizes builds by excluding unnecessary files
- [docker/README.md](docker/README.md) - Documentation for Docker setup and usage

## Features
- Uses Python 3.12-slim as base image
- Installs all dependencies using `uv` package manager
- Exposes port 8080 for the Streamlit interface
- Mounts the application directory as a volume for development
- Configurable through environment variables

## Testing
- [x] Tested local build and run
- [x] Verified environment variable configuration
- [x] Confirmed Streamlit interface accessibility at http://localhost:8080

## Documentation
Added comprehensive Docker documentation in `README.md` covering:
- Quick start guide
- Environment variable configuration
- Application access instructions